### PR TITLE
Add reference to Easypanel template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ docker exec -it servas php artisan key:generate --force
 7. Restart the containers with `docker-compose restart`.
 8. Open your browser and create a user account at https://your-servas-instance/register.
 
+### Easypanel
+
+Servas is available as a [Easypanel template](https://easypanel.io/docs/templates/servas)
+
 ### Manual
 
 **Requirements:**


### PR DESCRIPTION
This PR adds reference to the easypanel template of Servas, to make deployment easier and more accessable.
The template uses the official image, and uses a MariaDB database for deployment. It is possible to adjust storage, environment variables, even code!

This PR adds
- An update to the **README.md** providing a reference to the Easypanel template

Reason why you should merge
- Adds another method of deployment
- Easier method, less experience needed
- Port forwarding taken care of
- Easypanel doesn't cost anything for essential core features. You could have 1000 deployments of Servas and not pay anything!