### PR TITLE
[FEAT] Add command to delete duplicate links of a user

### DIFF
--- a/app/Console/Commands/CreateUserCommand.php
+++ b/app/Console/Commands/CreateUserCommand.php
@@ -6,7 +6,7 @@ use App\Actions\Fortify\CreateNewUser;
 use Illuminate\Console\Command;
 use Illuminate\Validation\ValidationException;
 
-class CreateUser extends Command
+class CreateUserCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/DeleteDuplicateLinksCommand.php
+++ b/app/Console/Commands/DeleteDuplicateLinksCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\LinkService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class DeleteDuplicateLinksCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'link:delete-duplicates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete the duplicate links of the user';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(LinkService $linkService): int
+    {
+        $userId = $this->ask('User ID');
+
+        try {
+            Validator::make(['id' => $userId], [
+                'id' => ['required', 'numeric'],
+            ])->validate();
+        } catch (ValidationException $exception) {
+            $this->error($exception->getMessage());
+            return Command::FAILURE;
+        }
+
+        $user = User::find($userId);
+
+        if (empty($user)) {
+            $this->error('The user does not exist.');
+
+            return Command::FAILURE;
+        }
+
+        $duplicates = $linkService->getDuplicates($user);
+
+        if (count($duplicates) === 0) {
+            $this->info('No duplicates found.');
+
+            return Command::SUCCESS;
+        }
+
+        if ($this->confirm(count($duplicates) . ' links found. Do you want to delete them?')) {
+            $linkService->deleteDuplicates($duplicates);
+
+            $this->info('Duplicate links deleted.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->error('Please confirm the deletion.');
+
+        return Command::FAILURE;
+    }
+}

--- a/app/Console/Commands/DeleteUserCommand.php
+++ b/app/Console/Commands/DeleteUserCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 
-class DeleteUser extends Command
+class DeleteUserCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/ListUsersCommand.php
+++ b/app/Console/Commands/ListUsersCommand.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use App\Models\User;
 use Illuminate\Console\Command;
 
-class ListUsers extends Command
+class ListUsersCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/ShowStatsCommand.php
+++ b/app/Console/Commands/ShowStatsCommand.php
@@ -7,7 +7,7 @@ use App\Models\Link;
 use Illuminate\Console\Command;
 use Spatie\Tags\Tag;
 
-class ShowStats extends Command
+class ShowStatsCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/app/Services/LinkService.php
+++ b/app/Services/LinkService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Link;
+use App\Models\User;
+
+class LinkService
+{
+    /**
+     * Get duplicate links of the user.
+     */
+    public function getDuplicates(User $user): array
+    {
+        $groupedLinks = Link::where('user_id', $user->id)->get(['id', 'link'])->groupBy('link')->toArray();;
+
+        return array_filter($groupedLinks, fn($group) => count($group) > 1);
+    }
+
+    /**
+     * Remove duplicate links.
+     */
+    public function deleteDuplicates(array $links): void
+    {
+        // TODO: Find a cleaner solution.
+        foreach ($links as $duplicates) {
+
+            if (!is_array($duplicates)) {
+                continue;
+            }
+
+            array_pop($duplicates);
+
+            if (empty($duplicates)) {
+                continue;
+            }
+
+            foreach ($duplicates as $duplicateLink) {
+                $link = Link::find($duplicateLink['id']);
+
+                $this->deleteLink($link);
+            }
+        }
+    }
+
+    /**
+     * Delete the link if not null.
+     */
+    public function deleteLink(?Link $link): void
+    {
+        if (is_null($link)) {
+            return;
+        }
+
+        $link->delete();
+    }
+}


### PR DESCRIPTION
This PR adds a command to delete the duplicate links of a particular user.
You can run the command with `./artisan link:delete-duplicates`. The prompt will ask for a user ID.

Related issue: #58