### PR TITLE
[TASK] Fill "linkFilter" storage with data from query parameters

### DIFF
--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -7,7 +7,6 @@ use App\Http\Requests\StoreLinkRequest;
 use App\Http\Requests\UpdateLinkRequest;
 use App\Models\Group;
 use App\Models\Link;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Auth;
@@ -24,8 +23,10 @@ class LinkController extends Controller
     public function index(array $filteredTags = []): Response
     {
         $searchString = Request::get('search') ?? '';
-        $filteredTags = Request::get('tags') ?? [];
+        $filteredTags = Request::get('tags') ?? '';
         $showUntaggedOnly = Request::get('untaggedOnly') ?? false;
+
+        $filteredTags = empty($filteredTags) ? [] : explode(',', $filteredTags);
 
         return Inertia::render('Links/Index', [
             'links' => Link::orderBy('created_at', 'desc')
@@ -44,6 +45,9 @@ class LinkController extends Controller
                     'id' => $link->id,
                 ]),
             'tags' => TagController::getAllTags(),
+            'searchString' => $searchString,
+            'filteredTags' => $filteredTags ? TagController::getTagsByNames($filteredTags) : [],
+            'showUntaggedOnly' => $showUntaggedOnly,
         ]);
     }
 

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -95,7 +96,7 @@ class TagController extends Controller
     /**
      * Returns all tags for the current user.
      */
-    public static function getAllTags()
+    public static function getAllTags(): array
     {
         return Tag::orderBy('name')
             ->filterByCurrentUser()
@@ -103,7 +104,28 @@ class TagController extends Controller
             ->transform(fn(Tag $tag) => [
                 'id' => $tag->id,
                 'name' => $tag->name,
-            ]);
+            ])
+            ->toArray();
+    }
+
+    /**
+     * Returns tags by their names.
+     */
+    public static function getTagsByNames(array $names): array
+    {
+        $locale = $locale ?? Tag::getLocale();
+
+        return Tag::where(function (Builder $query) use ($names, $locale) {
+            foreach ($names as $name) {
+                $query->orWhere("name->$locale", $name);
+            }
+        })
+            ->get()
+            ->transform(fn(Tag $tag) => [
+                'id' => $tag->id,
+                'name' => $tag->name,
+            ])
+            ->toArray();
     }
 
     /**

--- a/resources/js/Pages/Links/Index.svelte
+++ b/resources/js/Pages/Links/Index.svelte
@@ -12,11 +12,12 @@
     import LinkList from "@/Components/LinkList/LinkList.svelte";
     import Button from "@/Components/Buttons/Button.svelte";
     import {linkFilter} from "@/stores.js";
-    import {onDestroy} from "svelte";
+    import {onDestroy, onMount} from "svelte";
 
     export let links = [];
-
-    let searchString = '';
+    export let searchString = '';
+    export let filteredTags = [];
+    export let showUntaggedOnly = false;
 
     $title = 'Links';
 
@@ -37,11 +38,11 @@
         }
 
         router.get(route(route().current(), {
-            tags: $linkFilter.tags.map(item => item.name),
+            tags: $linkFilter.tags.length ? $linkFilter.tags.map(item => item.name).join(',') : null,
             search: searchString,
             untaggedOnly: $linkFilter.showUntaggedOnly ? true : null,
         }), {}, {
-            only: ['links'],
+            only: ['links', 'searchString'],
             preserveState: true,
         });
     }
@@ -49,6 +50,13 @@
     function removeFilteredTag(tag) {
         $linkFilter.tags = $linkFilter.tags.filter(item => item !== tag);
     }
+
+    onMount(() => {
+        if (filteredTags || showUntaggedOnly) {
+            $linkFilter.tags = filteredTags;
+            $linkFilter.showUntaggedOnly = showUntaggedOnly;
+        }
+    });
 
     onDestroy(() => {
         linkFilter.reset();
@@ -86,7 +94,8 @@
             </svg>
         </Button>
         {#if $linkFilter.showUntaggedOnly}
-            <button on:click={() => $linkFilter.showUntaggedOnly = false} type="button" class="block mt-2 mx-auto text-sm text-gray-700 sm:mt-0 sm:mr-0 sm:ml-2">
+            <button on:click={() => {$linkFilter.showUntaggedOnly = false; $linkFilter.isActive = true}} type="button"
+                    class="block mt-2 mx-auto text-sm text-gray-700 sm:mt-0 sm:mr-0 sm:ml-2">
                 Show all
             </button>
         {/if}
@@ -96,7 +105,7 @@
     {#if $linkFilter.tags.length}
         <div class="px-4 sm:px-0">
             {#each $linkFilter.tags as tag (tag.id)}
-                <button on:click={() => removeFilteredTag(tag)} type="button"
+                <button on:click={() => {removeFilteredTag(tag); $linkFilter.isActive = true}} type="button"
                         class="inline-flex items-center mr-2 mt-2 py-0.5 px-2.5 bg-primary-100 text-sm text-primary-800 font-medium rounded-full group">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
                          class="mr-1 -ml-1 w-4 h-4 fill-primary-500 rounded-full group-hover:fill-primary-700 group-hover:bg-primary-200/50">

--- a/resources/js/Pages/SingleLink/Index.svelte
+++ b/resources/js/Pages/SingleLink/Index.svelte
@@ -9,7 +9,7 @@
     import {dispatchCustomEvent, route} from "@/utils";
     import Main from "@/Layouts/AppLayout/Partials/Main.svelte";
     import Badge from "@/Components/Badge.svelte";
-    import {inertia} from "@inertiajs/svelte";
+    import {inertia, Link} from "@inertiajs/svelte";
 
     export let link = {};
 
@@ -102,8 +102,10 @@
         {#if link.tags.length}
             <div class="mt-2 space-y-2 sm:space-y-3">
                 {#each link.tags as tag (tag.id)}
-                    <Badge title={tag.name} noHover={true}
-                           class="mr-1.5 first:mt-2 last:mr-0 sm:first:mt-3"/>
+                    <Link href={route('links.index', {tags: tag.name})}
+                          class="inline-block mr-1.5 first:mt-2 last:mr-0 sm:first:mt-3">
+                        <Badge title={tag.name} noHover={true}/>
+                    </Link>
                 {/each}
             </div>
         {/if}


### PR DESCRIPTION
With this PR, the "linkFilter" storage is populated with data from query parameters to display the correct state on the "Links" page.
Also, the tag badges on the single link pages are now clickable to show only links with the selected tag.