### PR TITLE
Run FrankenPHP as non-root user

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,7 +4,7 @@
 	auto_https off
 }
 
-:80 {
+{$SERVER_NAME} {
     root /app/public
 
     encode zstd br gzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install && \
 FROM dunglas/frankenphp:php8.3-alpine
 WORKDIR /app
 
-ENV SERVER_NAME=:80
+ENV SERVER_NAME=:8080
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
@@ -55,7 +55,10 @@ COPY docker/config/custom-php-fpm.conf /usr/local/etc/php-fpm.d/zzz-custom-php-f
 
 RUN mkdir -p /var/cache/php/opcache && \
     chmod 700 /var/cache/php/opcache
+RUN chown -R www-data:www-data /app /data/caddy /config/caddy /var/cache/php
 
 COPY ./docker-entrypoint.sh /
+
+USER www-data
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/compose.prod.yaml
+++ b/docker/compose.prod.yaml
@@ -6,7 +6,7 @@ services:
     container_name: servas
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./.env:/app/.env
       - servas-db-sqlite:/app/database/database.sqlite

--- a/docker/config/custom-php-fpm.conf
+++ b/docker/config/custom-php-fpm.conf
@@ -1,6 +1,6 @@
 [www]
-user = root
-group = root
+user = www-data
+group = www-data
 
 pm = ondemand
 pm.max_children = 5

--- a/docker/mariadb-example/compose.prod.yaml
+++ b/docker/mariadb-example/compose.prod.yaml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - db
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./.env:/app/.env
 


### PR DESCRIPTION
Run FrankenPHP as `www-data` user, to improve security.

Use `:8080` server name by default, but allow to change it by setting `SERVER_NAME` environment variable.