### PR TITLE
fix: mount SQLite volume as directory to prevent migration errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ COPY docker/config/custom-php-fpm.conf /usr/local/etc/php-fpm.d/zzz-custom-php-f
 RUN mkdir -p /var/cache/php/opcache && \
     chmod 700 /var/cache/php/opcache
 
+RUN mkdir -p /app/database/sqlite
+
 COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ ! -f /app/database/database.sqlite ]; then
-    touch /app/database/database.sqlite
+if [ ! -f /app/database/sqlite/database.sqlite ]; then
+    touch /app/database/sqlite/database.sqlite
 fi
 
 cd /app

--- a/docker/.env.prod.example
+++ b/docker/.env.prod.example
@@ -9,5 +9,5 @@ SERVAS_SHOW_APP_VERSION=true
 
 # SQLite
 DB_CONNECTION=sqlite
-DB_DATABASE=/app/database/database.sqlite
+DB_DATABASE=/app/database/sqlite/database.sqlite
 DB_FOREIGN_KEYS=true

--- a/docker/compose.prod.yaml
+++ b/docker/compose.prod.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   servas:
     image: beromir/servas
@@ -9,7 +7,7 @@ services:
       - "8080:80"
     volumes:
       - ./.env:/app/.env
-      - servas-db-sqlite:/app/database/database.sqlite
+      - servas-db-sqlite:/app/database/sqlite
 
 volumes:
   servas-db-sqlite:

--- a/docker/mariadb-example/compose.prod.yaml
+++ b/docker/mariadb-example/compose.prod.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     image: mariadb:10.7.3


### PR DESCRIPTION
The named volume was mounted directly onto the `database.sqlite` file path. On a fresh deployment Docker has no file there, so it creates a directory in its place. The entrypoint's `touch` then fails silently and `php artisan migrate --force` bails with `SQLSTATE[HY000] [14] unable to open database file`, leaving the DB without its schema. The app then errors with `no such table: sessions`.

Mount the volume at `/app/database/sqlite/` instead and point `DB_DATABASE` at `sqlite/database.sqlite` inside it. The Dockerfile pre-creates the directory so the mount target always exists.